### PR TITLE
Fix label formatting in release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
       - 'area/tests'
   - title: 📖 Documentation
     labels:
-      - 'area/docs' 
+      - 'area/docs'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## What's new ?


### PR DESCRIPTION
**Description**

- This PR fixes label formatting issues in #68 

Corrected typos in Release Drafter labels:
- rea/docs corrected to 'area/docs'

This change align with the intended labels from the previously merged PR.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

